### PR TITLE
[WIP] API Endpoint Updates

### DIFF
--- a/src/Resources/Api.php
+++ b/src/Resources/Api.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TechnicPack\SolderClient\Resources;
+
+class Api
+{
+    public $api;
+	public $version;
+	public $steam;
+
+	public function __construct($properties)
+	{
+		foreach ($properties as $key => $val) {
+			$this->{$key} = $val;
+		}
+	}
+}

--- a/src/SolderClient.php
+++ b/src/SolderClient.php
@@ -9,6 +9,7 @@ use TechnicPack\SolderClient\Exception\InvalidURLException;
 use TechnicPack\SolderClient\Exception\UnauthorizedException;
 use TechnicPack\SolderClient\Resources\Modpack;
 use TechnicPack\SolderClient\Resources\Build;
+use TechnicPack\SolderClient\Resources\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
@@ -26,7 +27,7 @@ class SolderClient
     public static function factory($url, $key, $headers = [], $handler = null, $timeout = 3)
     {
         $client = null;
-        $url = self::validateUrl($url);
+        $url = rtrim($url, '/').'/';
         if (!$headers)
             $headers = ['User-Agent' => self::setupAgent()];
         if (!$handler)
@@ -146,6 +147,13 @@ class SolderClient
         }
 
         return new Build($response);
+    }
+
+    public function getApi()
+    {
+        $response = $this->handle('/');
+
+        return new Api($response);
     }
 
     public static function validateUrl($url)

--- a/tests/SolderClientTest.php
+++ b/tests/SolderClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     public function testAPIValidation()
     {
         $this->expectException(InvalidURLException::class);
-        SolderClient::factory('http://localhost/', 'C3gy35Um2pBE97xn90z0sUNhH1KbzI');
+        SolderClient::validateUrl('http://localhost/');
     }
 
     public function testInvalidKey()
@@ -104,6 +104,27 @@ class ClientTest extends TestCase
 
         $this->assertEquals(2, count($modpacks));
         $this->assertTrue(array_key_exists('hexxit', $modpacks));
+    }
+
+    public function testGetApi()
+    {
+        $body = '{"api":"TechnicSolder","version":"v0.7.3.1","stream":"DEV"}';
+
+        // Create a mock and queue two responses.
+        $mock = new MockHandler([
+            new Response(200, ['Content-Length' => 0], '{"valid":"Key Validated.","name":"SolderClientTest","created_at":"2016-12-26T11:33:46.000Z"}'),
+            new Response(200, ['Content-Length' => 0], $body),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+
+        $client = SolderClient::factory('http://localhost/api/', 'C3gy35Um2pBE97xn90z0sUNhH1KbzI99', [], $handler);
+
+        $api = $client->getApi();
+
+        $this->assertTrue(array_key_exists('api', $api));
+        $this->assertTrue(array_key_exists('version', $api));
+        $this->assertTrue(array_key_exists('stream', $api));
     }
 
     public function testMalformedGetModpacks1()


### PR DESCRIPTION
This PR covers two items, but they're very closely tied. 

1) This removes the check that an API ends in `api/` before every execution of an API request. The method SolderClient::validateUrl($url) remains and does still check that the given url ends in `api/`

2) More critically this adds a new Resource type `Api` with three attributes (`api`, `version` & `stream`) which returns data about the api endpoint. This provides data about the endpoint. 

**TODO:**
 - [ ] Add validation to make sure the endpoint is as expected. 